### PR TITLE
removed null param value for old language option

### DIFF
--- a/src/BlaspService.php
+++ b/src/BlaspService.php
@@ -88,7 +88,7 @@ class BlaspService extends BlaspExpressionService
      */
     public function configure(?array $profanities = null, ?array $falsePositives = null): self
     {
-        $blasp = new BlaspService(null, $profanities, $falsePositives);
+        $blasp = new BlaspService($profanities, $falsePositives);
 
         return $blasp;
     }


### PR DESCRIPTION
This pull request includes a minor change to the `configure` method in the `BlaspService` class. The change simplifies the instantiation of the `BlaspService` by removing an unnecessary `null` parameter.

* [`src/BlaspService.php`](diffhunk://#diff-2a4eb5994c2793a1b03c8d78d4b0e0cdd1ce4f478619843ba3aaa0c325f81312L91-R91): Modified the `configure` method to instantiate `BlaspService` without passing `null` as the first parameter.